### PR TITLE
Fix missing comma at fab fa-wizards-of-the-coast

### DIFF
--- a/fontawesome-5.json
+++ b/fontawesome-5.json
@@ -151,7 +151,7 @@
 	"fab fa-wolf-pack-battalion",
 	"fas fa-wine-glass",
 	"fab fa-wix",
-	"fab fa-wizards-of-the-coast"
+	"fab fa-wizards-of-the-coast",
 	"fab fa-windows",
 	"fas fa-window-restore",
 	"far fa-window-restore",


### PR DESCRIPTION
Added a missing comma on the "fab fa-wizards-of-the-coast" entry.